### PR TITLE
Fix light intensity issue after toggling

### DIFF
--- a/Lighting.js
+++ b/Lighting.js
@@ -105,6 +105,11 @@ function updateLightSource() {
 function toggleLight(event) {
   if (!event.target.checked) {
     // Store current values before turning off
+    originalLightAmbient = vec4(lightAmbient);
+    originalLightDiffuse = vec4(lightDiffuse);
+    originalLightSpecular = vec4(lightSpecular);
+
+    // Set lights to zero (off)
     lightAmbient = vec4(0.0, 0.0, 0.0, 1.0);
     lightDiffuse = vec4(0.0, 0.0, 0.0, 1.0);
     lightSpecular = vec4(0.0, 0.0, 0.0, 1.0);

--- a/Lighting.js
+++ b/Lighting.js
@@ -114,8 +114,15 @@ function toggleLight(event) {
     lightDiffuse = vec4(0.0, 0.0, 0.0, 1.0);
     lightSpecular = vec4(0.0, 0.0, 0.0, 1.0);
   } else {
-    // Restore values from color pickers
-    updateLightColors();
+    // Restore original values instead of reading from color pickers
+    lightAmbient = vec4(originalLightAmbient);
+    lightDiffuse = vec4(originalLightDiffuse);
+    lightSpecular = vec4(originalLightSpecular);
+
+    // Update color pickers to match restored values
+    ambientColorPicker.value = rgbToHex(lightAmbient);
+    diffuseColorPicker.value = rgbToHex(lightDiffuse);
+    specularColorPicker.value = rgbToHex(lightSpecular);
   }
 
   // Update products

--- a/Lighting.js
+++ b/Lighting.js
@@ -9,6 +9,9 @@ var lightAmbient = vec4(ambient, ambient, ambient, 1.0);
 var lightDiffuse = vec4(diffuse, diffuse, diffuse, 1.0);
 var lightSpecular = vec4(specular, specular, specular, 1.0);
 
+// Store original light values for restoration
+var originalLightAmbient, originalLightDiffuse, originalLightSpecular;
+
 var lightSourceSelect, lightToggle, lightTypeSelect;
 var ambientColorPicker, diffuseColorPicker, specularColorPicker;
 var lightXSlider, lightYSlider, lightZSlider;

--- a/Lighting.js
+++ b/Lighting.js
@@ -29,6 +29,11 @@ function initLightControls() {
   diffuseColorPicker = document.getElementById("diffuse-color");
   specularColorPicker = document.getElementById("specular-color");
 
+  // Store original light values for restoration
+  originalLightAmbient = vec4(lightAmbient);
+  originalLightDiffuse = vec4(lightDiffuse);
+  originalLightSpecular = vec4(lightSpecular);
+
   // Position sliders and values
   lightXSlider = document.getElementById("light-x");
   lightYSlider = document.getElementById("light-y");
@@ -63,7 +68,6 @@ function initLightControls() {
   spotlightDirZ.addEventListener("input", updateSpotlightParams);
   updateLightType();
 }
-
 function updateLightSource() {
   const isSpotlight = lightSourceSelect.value === "spot";
 


### PR DESCRIPTION
This PR fixes a bug where toggling the light off and back on causes it to appear brighter than before. This fixes issue #1 

## **Changes made:**

- Added variables to store original ambient, diffuse, and specular light values.
- Updated toggleLight to save current values before turning off and restore them when turning on.
- Synced color pickers with restored values.
- Modified updateLightColors to update both current and original values.